### PR TITLE
fix: parallel download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redivis
 Type: Package
 Title: R interface for Redivis
-Version: 0.6.5
+Version: 0.6.6
 Author: Redivis Inc.
 Maintainer: Redivis <support@redivis.com>
 Description: Supports working with Redivis datasets and tables through R. 

--- a/R/Table.R
+++ b/R/Table.R
@@ -265,8 +265,8 @@ Table <- setRefClass("Table",
      },
 
      download_files = function(path = getwd(), overwrite = FALSE, max_results = NULL, file_id_variable = NULL, progress=TRUE){
-        if (!endsWith(path, '/')) {
-          path = str_interp("${path}/")
+        if (endsWith(path, '/')) {
+          path <- str_sub(path,1,nchar(path)-1) # remove trailing "/", as this screws up file.path()
         }
 
         if (is.null(file_id_variable)){

--- a/R/Table.R
+++ b/R/Table.R
@@ -307,7 +307,6 @@ perform_table_parallel_file_download <- function(vec, path, overwrite){
   pb <- progressr::progressor(steps = length(vec))
   download_paths <- list()
   get_download_path_from_headers <- function(headers){
-    print(path)
     file_path <- base::file.path(path, headers$'x-redivis-filename')
     download_paths <<- append(download_paths, file_path)
     return(file_path)

--- a/R/Table.R
+++ b/R/Table.R
@@ -307,6 +307,7 @@ perform_table_parallel_file_download <- function(vec, path, overwrite){
   pb <- progressr::progressor(steps = length(vec))
   download_paths <- list()
   get_download_path_from_headers <- function(headers){
+    print(path)
     file_path <- base::file.path(path, headers$'x-redivis-filename')
     download_paths <<- append(download_paths, file_path)
     return(file_path)

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -146,12 +146,12 @@ perform_parallel_download <- function(paths, overwrite, get_download_path_from_h
       print(e)
       stop(e)
     }
-    curl::multi_add(h, fail = fail_fn, data = make_data_fn(h, url, get_download_path_from_headers, overwrite, on_finish), pool = pool)
+    curl::multi_add(h, fail = fail_fn, data = parallel_download_data_cb_factory(h, url, get_download_path_from_headers, overwrite, on_finish), pool = pool)
   }
   curl::multi_run(pool=pool)
 }
 
-make_data_fn <- function(h, url, get_download_path_from_headers, overwrite, on_finish){
+parallel_download_data_cb_factory <- function(h, url, get_download_path_from_headers, overwrite, on_finish){
   file_con <- NULL
   handle <- h
   path <- url
@@ -166,11 +166,8 @@ make_data_fn <- function(h, url, get_download_path_from_headers, overwrite, on_f
           return(NULL)
         }
       }
-      print(res_data)
-      print(handle)
 
       headers <- parse_curl_headers(res_data)
-      print(headers)
       download_path <- get_download_path_from_headers(headers)
       if (!overwrite && base::file.exists(download_path)){
         stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -169,6 +169,7 @@ parallel_download_data_cb_factory <- function(h, url, get_download_path_from_hea
 
       headers <- parse_curl_headers(res_data)
       download_path <- get_download_path_from_headers(headers)
+      print(headers)
       print(download_path)
       if (!overwrite && base::file.exists(download_path)){
         stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -142,40 +142,6 @@ perform_parallel_download <- function(paths, overwrite, get_download_path_from_h
     curl::handle_setheaders(h, "Authorization"=auth[[1]])
     curl::handle_setopt(h, "url"=url)
 
-    make_data_fn <- function(h, url, get_download_path_from_headers, overwrite, on_finish){
-      file_con <- NULL
-      handle <- h
-      path <- url
-      return(function(chunk, final){
-        if (is.null(file_con)){
-          res_data <- curl::handle_data(handle)
-          status_code <- res_data$status_code
-          if (status_code >= 400){
-            if (stop_on_error){
-              stop(str_interp("Received HTTP status ${status_code} for path ${path}"))
-            } else {
-              return(NULL)
-            }
-          }
-
-          headers <- parse_curl_headers(res_data)
-
-          download_path <- get_download_path_from_headers(headers)
-          if (!overwrite && base::file.exists(download_path)){
-            stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))
-          }
-          file_con <<- base::file(download_path, "w+b")
-        }
-        if (length(chunk)){
-          writeBin(chunk, file_con)
-        }
-        if (final){
-          on_finish()
-          close(file_con)
-        }
-      })
-    }
-
     fail_fn <- function(e){
       print(e)
       stop(e)
@@ -185,6 +151,41 @@ perform_parallel_download <- function(paths, overwrite, get_download_path_from_h
   curl::multi_run(pool=pool)
 }
 
+make_data_fn <- function(h, url, get_download_path_from_headers, overwrite, on_finish){
+  file_con <- NULL
+  handle <- h
+  path <- url
+  return(function(chunk, final){
+    if (is.null(file_con)){
+      res_data <- curl::handle_data(handle)
+      status_code <- res_data$status_code
+      if (status_code >= 400){
+        if (stop_on_error){
+          stop(str_interp("Received HTTP status ${status_code} for path ${path}"))
+        } else {
+          return(NULL)
+        }
+      }
+      print(res_data)
+      print(handle)
+
+      headers <- parse_curl_headers(res_data)
+      print(headers)
+      download_path <- get_download_path_from_headers(headers)
+      if (!overwrite && base::file.exists(download_path)){
+        stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))
+      }
+      file_con <<- base::file(download_path, "w+b")
+    }
+    if (length(chunk)){
+      writeBin(chunk, file_con)
+    }
+    if (final){
+      on_finish()
+      close(file_con)
+    }
+  })
+}
 
 
 make_paginated_request <- function(path, query=list(), page_size=100, max_results=NULL){

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -169,6 +169,7 @@ parallel_download_data_cb_factory <- function(h, url, get_download_path_from_hea
 
       headers <- parse_curl_headers(res_data)
       download_path <- get_download_path_from_headers(headers)
+      print(download_path)
       if (!overwrite && base::file.exists(download_path)){
         stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))
       }

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -123,7 +123,7 @@ parse_curl_headers <- function(res_data){
   vec <- curl::parse_headers(res_data$headers)
 
   header_names <- purrr::map(vec, function(header) {
-    strsplit(header, ':')[[1]][[1]]
+    tolower(strsplit(header, ':')[[1]][[1]])
   })
   headers <- purrr::map(vec, function(header) {
     split = strsplit(header, ':\\s+')[[1]]

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -169,8 +169,6 @@ parallel_download_data_cb_factory <- function(h, url, get_download_path_from_hea
 
       headers <- parse_curl_headers(res_data)
       download_path <- get_download_path_from_headers(headers)
-      print(headers)
-      print(download_path)
       if (!overwrite && base::file.exists(download_path)){
         stop(str_interp("File already exists at '${download_path}'. Set parameter overwrite=TRUE to overwrite existing files."))
       }


### PR DESCRIPTION
Fixes an issue introduced in 0.6.5 that caused issues with `table$download_files()` in linux.

File headers were incorrectly parsed on some systems, due to inconsistency in how curl handles casing of headers across systems.