### PR TITLE
fix: retryable file downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redivis
 Type: Package
 Title: R interface for Redivis
-Version: 0.11.2
+Version: 0.11.3
 Author: Redivis Inc.
 Maintainer: Redivis <support@redivis.com>
 Description: Supports working with Redivis API through R. 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Depends:
     R (>= 3.5.0)
 Imports:
     httr (>= 1.4.0),
-    curl (>= 5.0.0),
+    curl (>= 6.1.0),
     jsonlite (>= 1.8.0),
     data.table (>= 1.0.0),
     dplyr (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Depends:
     R (>= 3.5.0)
 Imports:
     httr (>= 1.4.0),
-    curl (>= 6.1.0),
+    curl (>= 5.0.0),
     jsonlite (>= 1.8.0),
     data.table (>= 1.0.0),
     dplyr (>= 1.0.0),

--- a/R/api_request.R
+++ b/R/api_request.R
@@ -261,10 +261,8 @@ perform_parallel_download <- function(
 ) {
   # limit open files
   max_parallelization <- max(min(128, length(paths), max_parallelization), 1)
-  streams_per_connection <- 5
   pool <- curl::new_pool(
-    total_con   = ceiling(max_parallelization / streams_per_connection),
-    max_streams = streams_per_connection
+    total_con   = ceiling(max(1, max_parallelization / 2)), # multiplexing allows us to have fewer connections, so divide by 2
   )
 
   # track open connections so we can clean up on exit

--- a/R/util.R
+++ b/R/util.R
@@ -305,14 +305,12 @@ parallel_download_raw_files <- function(self, path = getwd(), overwrite = FALSE,
 
 perform_parallel_raw_file_download <- function(vec, path, overwrite, max_parallelization){
   pb <- progressr::progressor(steps = length(vec))
-  download_paths <- list()
   get_download_path_from_headers <- function(headers){
     name <- get_filename_from_content_disposition(headers$'content-disposition')
     file_path <- base::file.path(path, name)
-    download_paths <<- append(download_paths, file_path)
     return(file_path)
   }
-  perform_parallel_download(
+  download_paths <- perform_parallel_download(
     purrr::map(vec, function(id){str_interp("/rawFiles/${id}")}),
     overwrite=overwrite,
     get_download_path_from_headers=get_download_path_from_headers,


### PR DESCRIPTION
Implements support for auto-retry of file downloads in `table$download_files()`, allowing for more graceful handling of intermittent network issues